### PR TITLE
Fixed missing , in Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -47,7 +47,7 @@ Vagrant.configure("2") do |config|
   debian7 = {
     :name   => "debian",
     :box    => "debian-7.0-amd64-minimal",
-    :url    => "https://dl.dropboxusercontent.com/s/xymcvez85i29lym/vagrant-debian-wheezy64.box"
+    :url    => "https://dl.dropboxusercontent.com/s/xymcvez85i29lym/vagrant-debian-wheezy64.box",
     :server => "server.sh",
     :node   => "node.sh"
   }


### PR DESCRIPTION
Noticed a missing comma after debian7 url.